### PR TITLE
Parse TAB characters as whitespace

### DIFF
--- a/autoload/vison/resolver.vim
+++ b/autoload/vison/resolver.vim
@@ -37,7 +37,7 @@ function! vison#resolver#get_query(lines)
 
   while i < l
     let c = joined[i]
-    if c ==# ' ' && mode != 6 && mode != 8
+    if (c ==# ' ' || c ==# "\t") && mode != 6 && mode != 8
       let i = i + 1
       continue
     endif


### PR DESCRIPTION
Fix completion failed if the json file contains TABs as whitespace.

This fix may also resolve #4.